### PR TITLE
Update RandomizableContainerBlockEntityMixin.java

### DIFF
--- a/src/main/java/melonslise/locks/mixin/RandomizableContainerBlockEntityMixin.java
+++ b/src/main/java/melonslise/locks/mixin/RandomizableContainerBlockEntityMixin.java
@@ -21,7 +21,7 @@ public class RandomizableContainerBlockEntityMixin {
     private void lockRandomizableContainerBlockEntity(int slot, CallbackInfoReturnable<ItemStack> cir) {
         BlockPos pos = ((BaseContainerBlockEntity) (Object) this).getBlockPos();
         Level level = ((BaseContainerBlockEntity) (Object) this).getLevel();
-        if (level.isClientSide) return;
+        if (level == null || level.isClientSide) return;
         if (LocksUtil.locked(level, pos)){
             cir.setReturnValue(Items.AIR.getDefaultInstance());
         }


### PR DESCRIPTION
fix render thread crash during feature gen when level is not populated.. i did not test this fix, but it's pretty simple.