### PR TITLE
Fix NPE when Transform is null

### DIFF
--- a/src/main/java/melonslise/locks/common/util/Lockable.java
+++ b/src/main/java/melonslise/locks/common/util/Lockable.java
@@ -19,6 +19,7 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
 import java.util.*;
+import java.util.Objects;
 
 public class Lockable extends Observable implements Observer
 {
@@ -87,7 +88,7 @@ public class Lockable extends Observable implements Observer
 	{
 		this.bb = bb;
 		this.lock = lock;
-		this.tr = tr;
+		this.tr = Objects.requireNonNull(tr);
 		this.stack = stack;
 		this.id = id;
 		lock.addObserver(this);
@@ -105,7 +106,7 @@ public class Lockable extends Observable implements Observer
 		CompoundTag nbt = new CompoundTag();
 		nbt.put(KEY_BB, Cuboid6i.toNbt(lkb.bb));
 		nbt.put(KEY_LOCK, Lock.toNbt(lkb.lock));
-		nbt.putByte(KEY_TRANSFORM, (byte) lkb.tr.ordinal());
+		nbt.putByte(KEY_TRANSFORM, (byte) (lkb.tr != null ? lkb.tr.ordinal() : 0));
 		nbt.put(KEY_STACK, lkb.stack.save(new CompoundTag()));
 		nbt.putInt(KEY_ID, lkb.id);
 		return nbt;

--- a/src/main/java/melonslise/locks/common/util/Transform.java
+++ b/src/main/java/melonslise/locks/common/util/Transform.java
@@ -45,7 +45,8 @@ public enum Transform
 
 	public static Transform fromDirectionAndFace(Direction dir, AttachFace face, Direction def)
 	{
-		return LOOKUP.get(Pair.of(dir.getAxis() == Direction.Axis.Y ? def : dir, face));
+		Transform result = LOOKUP.get(Pair.of(dir.getAxis() == Direction.Axis.Y ? def : dir, face));
+		return result != null ? result : NORTH_UP;
 	}
 
 	public static Transform fromDirection(Direction dir, Direction def)


### PR DESCRIPTION
Note: This analysis has been done by me with help of DeepSeek. I have manually reviewed and tested these changes.

Original issue happened with the following details:
Fabric 1.20.1 - Locks-Unofficial Version: 1.0.3hotfix

```
[00:18:50] [Server thread/ERROR]:Exception stopping the server
java.lang.NullPointerException: Cannot invoke "melonslise.locks.common.util.Transform.ordinal()" because "lkb.tr" is null
	at melonslise.locks.common.util.Lockable.toNbt(Lockable.java:108) ~[locks-fabric-1.20.1-1.0.3hotfix.jar:?]
	at melonslise.locks.common.components.LockableHandler.writeToNbt(LockableHandler.java:150) ~[locks-fabric-1.20.1-1.0.3hotfix.jar:?]
	at dev.onyxstudios.cca.internal.base.AbstractComponentContainer.toTag(AbstractComponentContainer.java:124) ~[cardinal-components-base-5.2.3-96afedfb1bc7e0ac.jar:?]
	at dev.onyxstudios.cca.internal.world.ComponentPersistentState.method_75(ComponentPersistentState.java:44) ~[cardinal-components-world-5.2.3-6a82c9aa79dabc53.jar:?]
	at net.minecraft.class_18.method_17919(class_18.java:36) ~[client-intermediary.jar:?]
	at net.minecraft.class_26.method_32384(class_26.java:122) ~[client-intermediary.jar:?]
	at java.util.HashMap.forEach(Unknown Source) ~[?:?]
``` 

# NullPointerException in Lockable.toNbt

Error: `java.lang.NullPointerException: Cannot invoke "melonslise.locks.common.util.Transform.ordinal()" because "lkb.tr" is null` at line 108 in Lockable.java.

Root cause: A Lockable instance exists with `tr` field null. This could happen if:
1. `Transform.fromDirection` returns null when `dir` is UP/DOWN and `def` is also UP/DOWN (both vertical). This occurs in world generation (`LocksUtil.lockWhenGen`) but there is a null check (line 210) that sets default to `Transform.NORTH_UP`.
2. Missing null check in `LockItem` calls? `Transform.fromDirection(ctx.getClickedFace(), player.getDirection().getOpposite())` should be safe because `def` is horizontal.
3. Possibly corrupted NBT data? `Lockable.fromNbt` uses `Transform.values()[byte]` which could throw ArrayIndexOutOfBounds if byte out of range, but not null.
4. `Lockable.fromBuf` uses `buf.readEnum` which could throw if invalid, but not null.

Thus the most likely scenario is that a Lockable was constructed with null Transform due to missing null check in some code path (maybe `LocksFeature` is enabled? It's commented out). Or there is a race condition where `Transform.fromDirection` returns null and caller doesn't check.

Fix options:
1. Add null check in `Lockable.toNbt` to handle existing corrupted lockables.
2. Add validation in `Lockable` constructor (`Objects.requireNonNull`).
3. Ensure `Transform.fromDirection` never returns null by adding default fallback.

Recommendations:
- In `Transform.fromDirection`, if result is null, return `Transform.NORTH_UP` (or throw IllegalArgumentException).
- In `Lockable` constructor, reject null Transform.
- In `Lockable.toNbt`, defensive null check with default.

Implement all three for robustness.